### PR TITLE
Wait for send to happen

### DIFF
--- a/test/integration/transactions.js
+++ b/test/integration/transactions.js
@@ -18,7 +18,7 @@ it('sends ether from one account to another', function () {
     const amount = 42
 
     return Promise.fromCallback((callback) =>
-      erisDb.txs().send(privateKey, destination, amount, null, callback)
+      erisDb.txs().sendAndHold(privateKey, destination, amount, null, callback)
     ).then(() => {
       return Promise.fromCallback((callback) =>
         erisDb.accounts().getAccount(destination, callback)


### PR DESCRIPTION
The problem with this test is that query the account that we are sending token to before the send has completed.